### PR TITLE
fix for memory overrun/corruption because of unmatched declarations

### DIFF
--- a/libraries/AD9850/AD9850.h
+++ b/libraries/AD9850/AD9850.h
@@ -31,6 +31,7 @@ class AD9850{
       int _FQUP;
       int _Data;
       int _quartzClock;
+      double _Freq;
 
       void write(byte word);
       void clock_CLK();


### PR DESCRIPTION
actual fix would include AD9850.h in AD9850.cpp instead of just matching declarations